### PR TITLE
fix: seperator num = cols + rows - 1

### DIFF
--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -486,7 +486,7 @@ NS_INLINE CGRect MMButtonRectMake(CGRect rect, CGRect contentRect, UIUserInterfa
         
         const NSUInteger totalColumns = 4;
         const NSUInteger totalRows = numbersPerLine + 1;
-        const NSUInteger numberOfSeparators = totalColumns * totalRows - 1;
+        const NSUInteger numberOfSeparators = totalColumns + totalRows - 1;
         
         if (separatorViews.count != numberOfSeparators) {
             [separatorViews makeObjectsPerformSelector:@selector(removeFromSuperview)];


### PR DESCRIPTION
When you calc how many seperators should be draw, your formula is wrong. 

The number of seperator should be: num = cols + rows - 1. 

The original formula is: num = cols * rows - 1.