### PR TITLE
Ask delegate whether keyboard should delete backward character.

### DIFF
--- a/Classes/MMNumberKeyboard.h
+++ b/Classes/MMNumberKeyboard.h
@@ -35,6 +35,15 @@
  */
 - (BOOL)numberKeyboardShouldReturn:(MMNumberKeyboard *)numberKeyboard;
 
+/**
+ *  Asks the delegate if the keyboard should remove the character just before the cursor.
+ *
+ *  @param numberKeyboard The keyboard whose return button was pressed.
+ *
+ *  @return Returns	@c YES if the keyboard should implement its default behavior for the delete backward button; otherwise, @c NO.
+ */
+- (BOOL)numberKeyboardShouldDeleteBackward:(MMNumberKeyboard *)numberKeyboard;
+
 @end
 
 /**

--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -253,7 +253,15 @@ static const CGFloat MMNumberKeyboardPadSpacing = 8.0f;
     
     // Handle backspace.
     else if (keyboardButton == MMNumberKeyboardButtonBackspace) {
-        [keyInput deleteBackward];
+        BOOL shouldDeleteBackward = YES;
+		
+        if ([delegate respondsToSelector:@selector(numberKeyboardShouldDeleteBackward:)]) {
+            shouldDeleteBackward = [delegate numberKeyboardShouldDeleteBackward:self];
+        }
+		
+        if (shouldDeleteBackward) {
+            [keyInput deleteBackward];
+        }
     }
     
     // Handle done.


### PR DESCRIPTION
Simply call optional 'numberKeyboardShouldDeleteBackward:' method on delegate.

YES by default if not implemented.

