### PR TITLE
Fixed button styling not being applied

### DIFF
--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -736,6 +736,8 @@ NS_INLINE CGRect MMButtonRectMake(CGRect rect, CGRect contentRect, UIUserInterfa
         buttonLayer.shadowOpacity = 1.0f;
         buttonLayer.shadowRadius = 0.0f;
     }
+
+    [self _updateButtonAppearance];
 }
 
 - (void)willMoveToWindow:(UIWindow *)newWindow

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -12,6 +12,7 @@
 @interface ViewController () <MMNumberKeyboardDelegate>
 
 @property (strong, nonatomic) UITextField *textField;
+@property (strong, nonatomic) MMNumberKeyboard *keyboard;
 
 @end
 
@@ -27,6 +28,8 @@
     MMNumberKeyboard *keyboard = [[MMNumberKeyboard alloc] initWithFrame:CGRectZero];
     keyboard.allowsDecimalPoint = YES;
     keyboard.delegate = self;
+
+    self.keyboard = keyboard;
     
     // Configure an example UITextField.
     UITextField *textField = [[UITextField alloc] initWithFrame:CGRectZero];
@@ -39,6 +42,23 @@
     self.textField = textField;
     
     [self.view addSubview:textField];
+
+    [textField addTarget:self action:@selector(textfieldChanged:) forControlEvents:UIControlEventEditingChanged];
+
+    [self updateReturnKeyStyleAccordingToTextFieldLength];
+}
+
+- (void)textfieldChanged:(UITextField *)field {
+    [self updateReturnKeyStyleAccordingToTextFieldLength];
+}
+
+- (void)updateReturnKeyStyleAccordingToTextFieldLength {
+    if (self.textField.text.length == 0) {
+        self.keyboard.returnKeyButtonStyle = MMNumberKeyboardButtonStyleGray;
+    }
+    else {
+        self.keyboard.returnKeyButtonStyle = MMNumberKeyboardButtonStyleDone;
+    }
 }
 
 #pragma mark - MMNumberKeyboardDelegate.


### PR DESCRIPTION
The return key button did not fully apply the new style. Only the text color was applied but not the background color.

Until now the background color update only happened after tapping the button (when -setHighlighted was called).