### PR TITLE
Add the possibility to customize the decimal separator character

### DIFF
--- a/Classes/MMNumberKeyboard.h
+++ b/Classes/MMNumberKeyboard.h
@@ -125,6 +125,15 @@ typedef NS_ENUM(NSUInteger, MMNumberKeyboardButtonStyle) {
 @property (assign, nonatomic) BOOL allowsDecimalPoint;
 
 /**
+ *  Set the character that will be used as decimal separator.
+ *  If @c nil, the default value is set.
+ *
+ *  @note The default value of this property is the default decimal separator of the current locale.
+ *  @param decimalCharacter The character that will be used as decimal separator.
+ */
+- (void) setDecimalCharacter:(NSString *)decimalCharacter;
+
+/**
  *  The visible title of the Return key.
  *
  *  @note The default visible title of the Return key is “Done”.

--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -383,6 +383,26 @@ static const CGFloat MMNumberKeyboardPadSpacing = 8.0f;
     }
 }
 
+- (void) setDecimalCharacter:(NSString *)decimalCharacter
+{
+    
+    UIButton* decimalPointButton = [self.buttonDictionary objectForKey:@(MMNumberKeyboardButtonDecimalPoint)];
+    
+    if (decimalCharacter != nil) {
+        
+        [decimalPointButton setTitle:decimalCharacter forState:UIControlStateNormal];
+        
+    }
+    else {
+        
+        NSLocale *locale = self.locale ?: [NSLocale currentLocale];
+        NSString *decimalSeparator = [locale objectForKey:NSLocaleDecimalSeparator];
+        [decimalPointButton setTitle:decimalSeparator ?: @"." forState:UIControlStateNormal];
+        
+    }
+    
+}
+
 - (void)setReturnKeyTitle:(NSString *)title
 {
     if (![title isEqualToString:self.returnKeyTitle]) {

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -28,6 +28,9 @@
     keyboard.allowsDecimalPoint = YES;
     keyboard.delegate = self;
     
+    // Uncomment this line to override the decimal separator character
+    // keyboard.decimalCharacter = @"🐼";
+    
     // Configure an example UITextField.
     UITextField *textField = [[UITextField alloc] initWithFrame:CGRectZero];
     textField.inputView = keyboard;


### PR DESCRIPTION
Hi,
I have added the possibility to customize the decimal separator character.
For example in France, the default separator is "," but I want to use this keyboard for phonenumber so I need it to be ".".

Example of usage :
`keyboard.decimalCharacter = @"🐼";`

And for resetting the character :
`keyboard.decimalCharacter = nil;`

Thanks !