### PR TITLE
Load image resource by name only to support asset catalogs

### DIFF
--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -632,17 +632,18 @@ NS_INLINE CGRect MMButtonRectMake(CGRect rect, CGRect contentRect, UIUserInterfa
     NSString *resource = [name stringByDeletingPathExtension];
     NSString *extension = [name pathExtension];
     
-    if (resource) {
-        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-        if (bundle) {
-            NSString *resourcePath = [bundle pathForResource:resource ofType:extension];
-            
-            return [UIImage imageWithContentsOfFile:resourcePath];
-        } else {
-            return [UIImage imageNamed:name];
-        }
+    if (!resource.length) {
+        return nil;
     }
-    return nil;
+
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *resourcePath = [bundle pathForResource:resource ofType:extension];
+
+    if (resourcePath.length) {
+        return [UIImage imageWithContentsOfFile:resourcePath];
+    }
+
+    return [UIImage imageNamed:resource];
 }
 
 @end


### PR DESCRIPTION
Fixes two things:

* uses `resource` instead of `name` for `imageNamed:` to support asset catalogs. This should still work with normal files as the `png` extension is never required.

* if a resource cannot be found via its path (as is the case when they are within asset catalogs), try `imageNamed:`

We integrate this library by integrating the source files directly into our project, and copy the resources into our asset catalog.

The changes should not break any existing code.