### PR TITLE
Fixed typo with protocol name

### DIFF
--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -319,7 +319,7 @@ static const CGFloat MMNumberKeyboardPadSpacing = 8.0f;
     }
     
     keyInput = [UIResponder MM_currentFirstResponder];
-    if (![keyInput conformsToProtocol:@protocol(UITextInput)]) {
+    if (![keyInput conformsToProtocol:@protocol(UIKeyInput)]) {
         NSLog(@"Warning: First responder %@ does not conform to the UIKeyInput protocol.", keyInput);
         return nil;
     }


### PR DESCRIPTION
Using MMNumberKeyboard on anything except for a UITextField or UITextView was resulting in the error "First responder <***** 0x10142f2c0> does not conform to the UIKeyInput protocol." even though the class did conform to the UIKeyInput protocol. After spending some time trying to work out what I was doing wrong, I discovered a typo in MMNumberKeyboard.