### PR TITLE
Fix Carthage support

### DIFF
--- a/MMNumberKeyboard.xcodeproj/project.pbxproj
+++ b/MMNumberKeyboard.xcodeproj/project.pbxproj
@@ -7,15 +7,31 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BEEDEF1A1D0A57F7007D16E2 /* MMNumberKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = BEEDEF181D0A57F7007D16E2 /* MMNumberKeyboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BEEDEF1B1D0A57F7007D16E2 /* MMNumberKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEDEF191D0A57F7007D16E2 /* MMNumberKeyboard.m */; };
+		5A6842E822FDFE02007180AB /* MMTextInputDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6842DE22FDFE01007180AB /* MMTextInputDelegateProxy.m */; };
+		5A6842E922FDFE02007180AB /* MMKeyboardButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6842DF22FDFE01007180AB /* MMKeyboardButton.h */; };
+		5A6842EA22FDFE02007180AB /* MMKeyboardTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6842E022FDFE01007180AB /* MMKeyboardTheme.m */; };
+		5A6842EB22FDFE02007180AB /* MMNumberKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6842E122FDFE01007180AB /* MMNumberKeyboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A6842EC22FDFE02007180AB /* MMTextInputDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6842E222FDFE01007180AB /* MMTextInputDelegateProxy.h */; };
+		5A6842ED22FDFE02007180AB /* MMKeyboardButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6842E322FDFE01007180AB /* MMKeyboardButton.m */; };
+		5A6842EE22FDFE02007180AB /* UIColor+MMNumberKeyboardAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6842E422FDFE01007180AB /* UIColor+MMNumberKeyboardAdditions.m */; };
+		5A6842EF22FDFE02007180AB /* MMKeyboardTheme.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6842E522FDFE01007180AB /* MMKeyboardTheme.h */; };
+		5A6842F022FDFE02007180AB /* MMNumberKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6842E622FDFE01007180AB /* MMNumberKeyboard.m */; };
+		5A6842F122FDFE02007180AB /* UIColor+MMNumberKeyboardAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6842E722FDFE01007180AB /* UIColor+MMNumberKeyboardAdditions.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5A6842DE22FDFE01007180AB /* MMTextInputDelegateProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMTextInputDelegateProxy.m; path = Classes/MMTextInputDelegateProxy.m; sourceTree = SOURCE_ROOT; };
+		5A6842DF22FDFE01007180AB /* MMKeyboardButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMKeyboardButton.h; path = Classes/MMKeyboardButton.h; sourceTree = SOURCE_ROOT; };
+		5A6842E022FDFE01007180AB /* MMKeyboardTheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMKeyboardTheme.m; path = Classes/MMKeyboardTheme.m; sourceTree = SOURCE_ROOT; };
+		5A6842E122FDFE01007180AB /* MMNumberKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMNumberKeyboard.h; path = Classes/MMNumberKeyboard.h; sourceTree = SOURCE_ROOT; };
+		5A6842E222FDFE01007180AB /* MMTextInputDelegateProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMTextInputDelegateProxy.h; path = Classes/MMTextInputDelegateProxy.h; sourceTree = SOURCE_ROOT; };
+		5A6842E322FDFE01007180AB /* MMKeyboardButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMKeyboardButton.m; path = Classes/MMKeyboardButton.m; sourceTree = SOURCE_ROOT; };
+		5A6842E422FDFE01007180AB /* UIColor+MMNumberKeyboardAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+MMNumberKeyboardAdditions.m"; path = "Classes/UIColor+MMNumberKeyboardAdditions.m"; sourceTree = SOURCE_ROOT; };
+		5A6842E522FDFE01007180AB /* MMKeyboardTheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMKeyboardTheme.h; path = Classes/MMKeyboardTheme.h; sourceTree = SOURCE_ROOT; };
+		5A6842E622FDFE01007180AB /* MMNumberKeyboard.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMNumberKeyboard.m; path = Classes/MMNumberKeyboard.m; sourceTree = SOURCE_ROOT; };
+		5A6842E722FDFE01007180AB /* UIColor+MMNumberKeyboardAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIColor+MMNumberKeyboardAdditions.h"; path = "Classes/UIColor+MMNumberKeyboardAdditions.h"; sourceTree = SOURCE_ROOT; };
 		BEEDEF0D1D0A5768007D16E2 /* MMNumberKeyboard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MMNumberKeyboard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEEDEF121D0A5768007D16E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BEEDEF181D0A57F7007D16E2 /* MMNumberKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMNumberKeyboard.h; path = Classes/MMNumberKeyboard.h; sourceTree = SOURCE_ROOT; };
-		BEEDEF191D0A57F7007D16E2 /* MMNumberKeyboard.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMNumberKeyboard.m; path = Classes/MMNumberKeyboard.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -48,8 +64,16 @@
 		BEEDEF0F1D0A5768007D16E2 /* MMNumberKeyboard */ = {
 			isa = PBXGroup;
 			children = (
-				BEEDEF181D0A57F7007D16E2 /* MMNumberKeyboard.h */,
-				BEEDEF191D0A57F7007D16E2 /* MMNumberKeyboard.m */,
+				5A6842DF22FDFE01007180AB /* MMKeyboardButton.h */,
+				5A6842E322FDFE01007180AB /* MMKeyboardButton.m */,
+				5A6842E522FDFE01007180AB /* MMKeyboardTheme.h */,
+				5A6842E022FDFE01007180AB /* MMKeyboardTheme.m */,
+				5A6842E122FDFE01007180AB /* MMNumberKeyboard.h */,
+				5A6842E622FDFE01007180AB /* MMNumberKeyboard.m */,
+				5A6842E222FDFE01007180AB /* MMTextInputDelegateProxy.h */,
+				5A6842DE22FDFE01007180AB /* MMTextInputDelegateProxy.m */,
+				5A6842E722FDFE01007180AB /* UIColor+MMNumberKeyboardAdditions.h */,
+				5A6842E422FDFE01007180AB /* UIColor+MMNumberKeyboardAdditions.m */,
 				BEEDEF121D0A5768007D16E2 /* Info.plist */,
 			);
 			path = MMNumberKeyboard;
@@ -62,7 +86,11 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BEEDEF1A1D0A57F7007D16E2 /* MMNumberKeyboard.h in Headers */,
+				5A6842EB22FDFE02007180AB /* MMNumberKeyboard.h in Headers */,
+				5A6842F122FDFE02007180AB /* UIColor+MMNumberKeyboardAdditions.h in Headers */,
+				5A6842EC22FDFE02007180AB /* MMTextInputDelegateProxy.h in Headers */,
+				5A6842E922FDFE02007180AB /* MMKeyboardButton.h in Headers */,
+				5A6842EF22FDFE02007180AB /* MMKeyboardTheme.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,6 +134,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = BEEDEF031D0A5768007D16E2;
@@ -133,7 +162,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BEEDEF1B1D0A57F7007D16E2 /* MMNumberKeyboard.m in Sources */,
+				5A6842ED22FDFE02007180AB /* MMKeyboardButton.m in Sources */,
+				5A6842E822FDFE02007180AB /* MMTextInputDelegateProxy.m in Sources */,
+				5A6842F022FDFE02007180AB /* MMNumberKeyboard.m in Sources */,
+				5A6842EA22FDFE02007180AB /* MMKeyboardTheme.m in Sources */,
+				5A6842EE22FDFE02007180AB /* UIColor+MMNumberKeyboardAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Closes #43

All the private headers and implementation files was missing in the Xcode project. These are now added as project headers. This fixes the build with Carthage.