### PR TITLE
Fix layout bug

### DIFF
--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -620,6 +620,8 @@ NS_INLINE CGRect MMButtonRectMake(CGRect rect, CGRect contentRect, BOOL usesRoun
             if (!allowsDecimalPoint) {
                 rect.size.width = numberSize.width * 2.0f;
                 [button setContentEdgeInsets:UIEdgeInsetsMake(0, 0, 0, numberSize.width)];
+            } else {
+                [button setContentEdgeInsets:UIEdgeInsetsZero];
             }
             
         } else {


### PR DESCRIPTION
![](https://s1.ax1x.com/2020/09/09/w8BJZq.jpg)

fix a layout bug:

Set the ``allowsDecimalPoint`` to ``true``, after it turned to ``true``，then set it to ``false`` . As it shown in the picture ,the zero key  became blank.